### PR TITLE
chore(open-telemetry): remove redundant `setStatus` on null exception

### DIFF
--- a/src/open-telemetry/src/Concerns/SpanRecordThrowable.php
+++ b/src/open-telemetry/src/Concerns/SpanRecordThrowable.php
@@ -21,8 +21,6 @@ trait SpanRecordThrowable
     protected function spanRecordException(SpanInterface $span, ?Throwable $e = null): void
     {
         if ($e === null) {
-            $span->setStatus(StatusCode::STATUS_OK);
-
             return;
         }
 

--- a/src/open-telemetry/tests/Listener/ClientRequestListenerTest.php
+++ b/src/open-telemetry/tests/Listener/ClientRequestListenerTest.php
@@ -63,7 +63,7 @@ class ClientRequestListenerTest extends TestCase
 
         $this->assertSame('GET /path', $span->getName());
         $this->assertSame(SpanKind::KIND_SERVER, $span->getKind());
-        $this->assertSame(StatusCode::STATUS_OK, $span->getStatus()->getCode());
+        $this->assertSame(StatusCode::STATUS_UNSET, $span->getStatus()->getCode());
         $this->assertSame('GET', $attributes->get('http.request.method'));
         $this->assertSame('http://localhost:80/path?field1=value1&field2=value2', $attributes->get('url.full'));
         $this->assertSame('/path', $attributes->get('url.path'));


### PR DESCRIPTION
Based on the official explanation: https://opentelemetry.io/docs/concepts/signals/traces/#span-status,

> In most cases, it is not necessary to explicitly mark a span as `Ok`.